### PR TITLE
Reformat error handling

### DIFF
--- a/client/src/components/forms/EventForm.tsx
+++ b/client/src/components/forms/EventForm.tsx
@@ -103,7 +103,7 @@ interface EventFormProps{
     btn: string;
     event?: EventModel; // can use a '?' to mark option types in an interface (same as in classes/types etc.)
     creator: Organizer;
-    formErrors: FormErrors[];
+    formErrors: { [path: string]: FormErrors };
     submitCallback: Function;
 }
 

--- a/client/src/components/forms/LoginForm.tsx
+++ b/client/src/components/forms/LoginForm.tsx
@@ -76,7 +76,6 @@ const LoginForm = () => {
             .then( () => successCallback())
             .catch( errors => {
                 const errorResponse = errors.response.data.errors;
-                console.log(errorResponse)
                 const errorDict: { [path: string]: FormErrors } = {};
                 for( const key of Object.keys(errorResponse)){
                     errorDict[errorResponse[key].path] = {

--- a/client/src/components/forms/LoginForm.tsx
+++ b/client/src/components/forms/LoginForm.tsx
@@ -42,7 +42,7 @@ const LoginForm = () => {
     const navigate = useNavigate();
     const [oneOrganizer, dispatch] = React.useReducer( reducer, new LoginOrganizer());
     const [showPassword, setShowPassword] = React.useState<boolean>(false);
-    const [ errors, setErrors ] = React.useState<FormErrors[]>([]);
+    const [ errors, setErrors ] = React.useState<{ [path: string]: FormErrors }>({});
 
     const handleChange = ( event: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = event.target;
@@ -76,14 +76,15 @@ const LoginForm = () => {
             .then( () => successCallback())
             .catch( errors => {
                 const errorResponse = errors.response.data.errors;
-                const errorList: FormErrors[] = [];
+                console.log(errorResponse)
+                const errorDict: { [path: string]: FormErrors } = {};
                 for( const key of Object.keys(errorResponse)){
-                    errorList.push({
+                    errorDict[errorResponse[key].path] = {
                         path: errorResponse[key].path,
                         message: errorResponse[key].message
-                    });
+                    };
                 }
-                setErrors(errorList);
+                setErrors(errorDict);
             });
     };
 

--- a/client/src/components/forms/RegisterForm.tsx
+++ b/client/src/components/forms/RegisterForm.tsx
@@ -45,7 +45,7 @@ const RegisterForm = () => {
         showPassword: false,
         showConfirmPassword: false
     });
-    const [ errors, setErrors ] = React.useState<FormErrors[]>([]);
+    const [ errors, setErrors ] = React.useState<{ [path: string]: FormErrors }>({});
 
     const handleChange = ( event: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = event.target;
@@ -80,15 +80,15 @@ const RegisterForm = () => {
             .then( () => successCallback() )
             .catch( errors => {
                 const errorResponse = errors.response.data.errors;
-                const errorList: FormErrors[] = [];
+                const errorDict: { [path: string]: FormErrors } = {};
                 for( const key of Object.keys(errorResponse)){
-                    errorList.push({
+                    errorDict[errorResponse[key].path] = {
                         path: errorResponse[key].path,
                         message: errorResponse[key].message
-                    })
+                    };
                 }
-                setErrors(errorList);
-            });
+                setErrors(errorDict);
+            })
     };
 
     return (

--- a/client/src/views/CreateEvent.tsx
+++ b/client/src/views/CreateEvent.tsx
@@ -15,24 +15,23 @@ interface FormErrors{
 
 const CreateEvent = () => {
     const nav = useNavigate();
-    const [ errors, setErrors ] = React.useState<FormErrors[]>([]);
+    const [ errors, setErrors ] = React.useState<{ [path: string]: FormErrors }>({});
     const [ currentOrganizer, setCurrentOrganizer ] = React.useState<Organizer>(new Organizer());
 
-//! ======== Needs Create Routes==============
     const onCreate = (thisEvent: EventModel) => {
         axios.post(process.env.REACT_APP_SERVER_URL+'/api/events/new', thisEvent)
             .then( () => nav('/dashboard'))
             .catch( errors => {
                 const errorResponse = errors.response.data.errors;
-                const errorList: FormErrors[] = [];
+                const errorDict: { [path: string]: FormErrors } = {};
                 for( const key of Object.keys(errorResponse)){
-                    errorList.push({
+                    errorDict[errorResponse[key].path] = {
                         path: errorResponse[key].path,
                         message: errorResponse[key].message
-                    })
+                    };
                 }
-                setErrors(errorList);
-            })
+                setErrors(errorDict);
+            });
     }
 
 

--- a/client/src/views/UpdateEvent.tsx
+++ b/client/src/views/UpdateEvent.tsx
@@ -16,7 +16,7 @@ const UpdateEvent = () => {
     const { id } = useParams();
     const [thisEvent, setThisEvent] = React.useState<EventModelForView>(new EventModelForView('','','','', new Date(), 1, new Organizer('fName', 'lName', 'email'), []));
     const [loaded, setLoaded] = React.useState(false);
-    const [errors, setErrors] = React.useState<FormErrors[]>([]);
+    const [errors, setErrors] = React.useState<{ [path: string]: FormErrors }>({});
     const nav = useNavigate();
 
     React.useEffect(() => {
@@ -44,13 +44,16 @@ const UpdateEvent = () => {
 
                 nav('/dashboard');
             })
-            .catch(err=>{
-                const errorResponse = err.response.data.error.errors;
-                const errorArr = [];
-                for (const key of Object.keys(errorResponse)) {
-                    errorArr.push(errorResponse[key].message)
+            .catch( errors => {
+                const errorResponse = errors.response.data.errors;
+                const errorDict: { [path: string]: FormErrors } = {};
+                for( const key of Object.keys(errorResponse)){
+                    errorDict[errorResponse[key].path] = {
+                        path: errorResponse[key].path,
+                        message: errorResponse[key].message
+                    };
                 }
-            setErrors(errorArr);
+                setErrors(errorDict);
             })
     }
 


### PR DESCRIPTION
To support adding form validation errors, reformatted responses to return form validations errors in dictionary objects instead of list form. Will make rendering them by field reference easier for front end.

Updated error format for:
-Login
-Registration
-Create Event
-Update Event
