### PR TITLE
45 non form validation errors on axios request cause error handling to break

### DIFF
--- a/client/src/components/EventDisplay.tsx
+++ b/client/src/components/EventDisplay.tsx
@@ -67,7 +67,7 @@ const EventDisplay = (props: EventDisplayProps) => {
                 response.data.organizer.lastName,
                 response.data.organizer.email
             )))
-            .catch(errors => console.log(errors));
+            .catch(errors => console.error(errors));
     },[]);
 
     return (<>

--- a/client/src/components/buttons/DeleteButton.tsx
+++ b/client/src/components/buttons/DeleteButton.tsx
@@ -15,7 +15,7 @@ const DeleteButton = (props: DeleteButtonProps) => {
     const deleteEvent = () => {
         axios.delete(process.env.REACT_APP_SERVER_URL+'/api/'+entityType+'/delete/'+_id)
             .then( () => successCallback() )
-            .catch(errors => console.log(errors));
+            .catch(errors => console.error(errors));
     };
 
     return (

--- a/client/src/components/buttons/LogoutButton.tsx
+++ b/client/src/components/buttons/LogoutButton.tsx
@@ -20,7 +20,7 @@ export const LogoutButton = () => {
         event.preventDefault();
         axios.post(process.env.REACT_APP_SERVER_URL+'/api/organizers/logout')
             .then(() => successCallback())
-            .catch(errors => console.log(errors));
+            .catch(errors => console.error(errors));
     }
 
     return(

--- a/client/src/components/forms/LoginForm.tsx
+++ b/client/src/components/forms/LoginForm.tsx
@@ -75,15 +75,19 @@ const LoginForm = () => {
         axios.post(process.env.REACT_APP_SERVER_URL+'/api/organizers/login', oneOrganizer )
             .then( () => successCallback())
             .catch( errors => {
-                const errorResponse = errors.response.data.errors;
-                const errorDict: { [path: string]: FormErrors } = {};
-                for( const key of Object.keys(errorResponse)){
-                    errorDict[errorResponse[key].path] = {
-                        path: errorResponse[key].path,
-                        message: errorResponse[key].message
-                    };
+                const errorResponse = errors.response?.data.errors;
+                if(errorResponse){
+                    const errorDict: { [path: string]: FormErrors } = {};
+                    for( const key of Object.keys(errorResponse)){
+                        errorDict[errorResponse[key].path] = {
+                            path: errorResponse[key].path,
+                            message: errorResponse[key].message
+                        };
+                    }
+                    setErrors(errorDict);
+                } else {
+                    console.error(errors)
                 }
-                setErrors(errorDict);
             });
     };
 

--- a/client/src/components/forms/RegisterForm.tsx
+++ b/client/src/components/forms/RegisterForm.tsx
@@ -79,15 +79,19 @@ const RegisterForm = () => {
         axios.post(process.env.REACT_APP_SERVER_URL+'/api/organizers/register', oneOrganizer )
             .then( () => successCallback() )
             .catch( errors => {
-                const errorResponse = errors.response.data.errors;
-                const errorDict: { [path: string]: FormErrors } = {};
-                for( const key of Object.keys(errorResponse)){
-                    errorDict[errorResponse[key].path] = {
-                        path: errorResponse[key].path,
-                        message: errorResponse[key].message
-                    };
+                const errorResponse = errors.response?.data.errors;
+                if(errorResponse){
+                    const errorDict: { [path: string]: FormErrors } = {};
+                    for( const key of Object.keys(errorResponse)){
+                        errorDict[errorResponse[key].path] = {
+                            path: errorResponse[key].path,
+                            message: errorResponse[key].message
+                        };
+                    }
+                    setErrors(errorDict);
+                } else {
+                    console.error(errors)
                 }
-                setErrors(errorDict);
             })
     };
 

--- a/client/src/views/CreateEvent.tsx
+++ b/client/src/views/CreateEvent.tsx
@@ -22,15 +22,19 @@ const CreateEvent = () => {
         axios.post(process.env.REACT_APP_SERVER_URL+'/api/events/new', thisEvent)
             .then( () => nav('/dashboard'))
             .catch( errors => {
-                const errorResponse = errors.response.data.errors;
-                const errorDict: { [path: string]: FormErrors } = {};
-                for( const key of Object.keys(errorResponse)){
-                    errorDict[errorResponse[key].path] = {
-                        path: errorResponse[key].path,
-                        message: errorResponse[key].message
-                    };
+                const errorResponse = errors.response?.data.errors;
+                if(errorResponse){
+                    const errorDict: { [path: string]: FormErrors } = {};
+                    for( const key of Object.keys(errorResponse)){
+                        errorDict[errorResponse[key].path] = {
+                            path: errorResponse[key].path,
+                            message: errorResponse[key].message
+                        };
+                    }
+                    setErrors(errorDict);
+                } else {
+                    console.error(errors)
                 }
-                setErrors(errorDict);
             });
     }
 

--- a/client/src/views/Dashboard.tsx
+++ b/client/src/views/Dashboard.tsx
@@ -60,7 +60,7 @@ const Dashboard = () => {
                 response.data.organizer.lastName,
                 response.data.organizer.email
             )))
-            .catch(errors => console.log(errors));
+            .catch(errors => console.error(errors));
     },[]);
 
     function dateChange(date: string){

--- a/client/src/views/EventPage.tsx
+++ b/client/src/views/EventPage.tsx
@@ -22,7 +22,7 @@ const EventPage = () => {
                 res.data.event.organizer,
                 res.data.event.users
             )))
-            .catch(errors => console.log(errors))
+            .catch(errors => console.error(errors))
     },[id])
     return (<>
         <HeaderBar title={thisEvent.name} btnTitle='Logout' btnRoute='logout'/>

--- a/client/src/views/Main.tsx
+++ b/client/src/views/Main.tsx
@@ -54,7 +54,7 @@ const Main = () => {
                 setAllEvents(response.data.events);
                 setLoaded(true);
             })
-            .catch(errors => console.log(errors));
+            .catch(errors => console.error(errors));
     }, []);
 
     return (<div >

--- a/client/src/views/UpdateEvent.tsx
+++ b/client/src/views/UpdateEvent.tsx
@@ -45,15 +45,19 @@ const UpdateEvent = () => {
                 nav('/dashboard');
             })
             .catch( errors => {
-                const errorResponse = errors.response.data.errors;
-                const errorDict: { [path: string]: FormErrors } = {};
-                for( const key of Object.keys(errorResponse)){
-                    errorDict[errorResponse[key].path] = {
-                        path: errorResponse[key].path,
-                        message: errorResponse[key].message
-                    };
+                const errorResponse = errors.response?.data.errors;
+                if(errorResponse){
+                    const errorDict: { [path: string]: FormErrors } = {};
+                    for( const key of Object.keys(errorResponse)){
+                        errorDict[errorResponse[key].path] = {
+                            path: errorResponse[key].path,
+                            message: errorResponse[key].message
+                        };
+                    }
+                    setErrors(errorDict);
+                } else {
+                    console.error(errors)
                 }
-                setErrors(errorDict);
             })
     }
 


### PR DESCRIPTION
- Update so non-form validation errors don't break the error handling logic on the axios calls
- Update all axios error response to use console.error() instead of console.log(). This will cause them to be flagged as errors and more obvious to the user that there a connectivity issue.

![Screen Shot 2022-10-14 at 10 17 56](https://user-images.githubusercontent.com/91854538/195904674-0c8fdd50-81d7-45e1-b1ec-d4d9b1a9b247.png)
