### PR TITLE
Event Page changes

### DIFF
--- a/client/src/components/EventDisplay.tsx
+++ b/client/src/components/EventDisplay.tsx
@@ -51,24 +51,14 @@ const dropDownStyle = {
 
 interface EventDisplayProps{
     event: EventModelForView;
+    current: Organizer;
 }
 
 const EventDisplay = (props: EventDisplayProps) => {
     const [openOrg, setOpenOrg] = React.useState(false);
     const nav = useNavigate();
     const thisEvent = props.event;
-    const [ currentOrganizer, setCurrentOrganizer ] = React.useState<Organizer>(new Organizer());
-    
-    React.useEffect(() => {
-        axios.get(process.env.REACT_APP_SERVER_URL+'/api/organizers/current')
-            .then(response => setCurrentOrganizer( new Organizer(
-                response.data.organizer._id,
-                response.data.organizer.firstName,
-                response.data.organizer.lastName,
-                response.data.organizer.email
-            )))
-            .catch(errors => console.error(errors));
-    },[]);
+    const currentOrganizer = props.current;
 
     return (<>
     <Box sx={{ flexGrow: 1, margin: '0px 10%'}}>

--- a/client/src/components/EventDisplay.tsx
+++ b/client/src/components/EventDisplay.tsx
@@ -171,23 +171,34 @@ const EventDisplay = (props: EventDisplayProps) => {
                 </Item>
             </Grid>
             </Grid>
-        <Grid xs={12} md={12} lg={12}
-        container
+        <Grid container xs={12} md={12} lg={12}
+        spacing={2}
         >
-            { currentOrganizer.organizerId ?
+            { currentOrganizer.organizerId ? thisEvent.organizer.organizerId === currentOrganizer.organizerId ?
+            <>
             <Grid xs={6} md={6} lg={6}>
                 <Item onClick={() => nav('/dashboard') }>Dashboard</Item>
             </Grid>
+            <Grid xs={6} md={6} lg={6}>
+                <Item onClick={() => nav('/event/update/'+thisEvent._id) }>Edit</Item>
+            </Grid></>
             :
+            <>
+            <Grid xs={3} md={3} lg={3}></Grid>
+            <Grid xs={6} md={6} lg={6}>
+                <Item onClick={() => nav('/dashboard') }>Dashboard</Item>
+            </Grid>
+            <Grid xs={3} md={3} lg={3}></Grid>
+            </>
+            :
+            <>
+            <Grid xs={3} md={3} lg={3}></Grid>
             <Grid xs={6} md={6} lg={6}>
                 <Item onClick={() => nav('/') }>Home</Item>
             </Grid>
+            <Grid xs={3} md={3} lg={3}></Grid>
+            </>
             }
-            { thisEvent.organizer.organizerId === currentOrganizer.organizerId ?
-            <Grid xs={6} md={6} lg={6}>
-                <Item onClick={() => nav('/event/update/'+thisEvent._id) }>Edit</Item>
-            </Grid>
-            : null }
             </Grid>
         </Grid>
     </Box>

--- a/client/src/components/forms/EventForm.tsx
+++ b/client/src/components/forms/EventForm.tsx
@@ -404,7 +404,7 @@ const EventForm = (props: EventFormProps) => {
                         <Typography>Event Organizer</Typography>
                     </AccordionSummary>
                     <AccordionDetails sx={{position: 'absolute', left: '5%', right: '5%', margin: '0', padding: '0' }}>
-                        <Typography>
+                        <Typography component={'span'}>
                             <Box style={ boxStyle2 }>
                             <TextField
                             style={ addForm }
@@ -479,7 +479,7 @@ const EventForm = (props: EventFormProps) => {
         <Typography >Add New Users</Typography>
     </AccordionSummary>
     <AccordionDetails sx={{position: 'absolute', left: '5%', right: '5%', margin: '0', padding: '0' }}>
-        <Typography>
+        <Typography component={'span'}>
             <Box
             style={ boxStyle2 }
             component="form"
@@ -541,7 +541,7 @@ const EventForm = (props: EventFormProps) => {
             <Typography >Add New Users</Typography>
         </AccordionSummary>
         <AccordionDetails sx={{position: 'absolute', left: '5%', right: '5%', margin: '0', padding: '0' }}>
-            <Typography>
+            <Typography component={'span'}>
                 <Box
                 style={ boxStyle2 }
                 component="form"
@@ -602,7 +602,7 @@ const EventForm = (props: EventFormProps) => {
         <Typography >Add New Users</Typography>
     </AccordionSummary>
     <AccordionDetails sx={{position: 'absolute', left: '5%', right: '5%', margin: '0', padding: '0' }}>
-        <Typography>
+        <Typography component={'span'}>
             <Box
             style={ boxStyle2 }
             component="form"

--- a/client/src/views/EventPage.tsx
+++ b/client/src/views/EventPage.tsx
@@ -5,6 +5,7 @@ import axios from 'axios'
 import { useParams } from 'react-router-dom'
 import Organizer from '../models/Organizer'
 import EventModelForView from '../models/EventModelForView'
+import { CommentsDisabledOutlined } from '@mui/icons-material'
 
 const EventPage = () => {
     const { id } = useParams()
@@ -23,10 +24,29 @@ const EventPage = () => {
                 res.data.event.users
             )))
             .catch(errors => console.error(errors))
-    },[id])
+    },[id]);
+
+    const [ currentOrganizer, setCurrentOrganizer ] = React.useState<Organizer>(new Organizer());
+    
+    React.useEffect(() => {
+        axios.get(process.env.REACT_APP_SERVER_URL+'/api/organizers/current')
+            .then(response => {
+                console.log(response);
+                setCurrentOrganizer( new Organizer(
+                response.data.organizer._id,
+                response.data.organizer.firstName,
+                response.data.organizer.lastName,
+                response.data.organizer.email
+            ))})
+            .catch(errors => console.error(errors));
+    },[]);
+
     return (<>
-        <HeaderBar title={thisEvent.name} btnTitle='Logout' btnRoute='logout'/>
-        <EventDisplay event={ thisEvent }/>
+        { currentOrganizer.organizerId ?
+        <HeaderBar title={thisEvent.name} btnTitle='Logout' btnRoute='logout'/> :
+
+        <HeaderBar title={thisEvent.name} btnTitle='Home' btnRoute=''/>}
+        <EventDisplay current={ currentOrganizer } event={ thisEvent }/>
     </>)
 }
 

--- a/client/src/views/EventPage.tsx
+++ b/client/src/views/EventPage.tsx
@@ -5,7 +5,6 @@ import axios from 'axios'
 import { useParams } from 'react-router-dom'
 import Organizer from '../models/Organizer'
 import EventModelForView from '../models/EventModelForView'
-import { CommentsDisabledOutlined } from '@mui/icons-material'
 
 const EventPage = () => {
     const { id } = useParams()

--- a/client/src/views/EventPage.tsx
+++ b/client/src/views/EventPage.tsx
@@ -44,7 +44,7 @@ const EventPage = () => {
         { currentOrganizer.organizerId ?
         <HeaderBar title={thisEvent.name} btnTitle='Logout' btnRoute='logout'/> :
 
-        <HeaderBar title={thisEvent.name} btnTitle='Home' btnRoute=''/>}
+        <HeaderBar title={thisEvent.name} btnTitle='Login' btnRoute='login'/>}
         <EventDisplay current={ currentOrganizer } event={ thisEvent }/>
     </>)
 }


### PR DESCRIPTION
resolves #37
resolves #38

Event Display Buttons Organized to be evenly spaced if two, or centered if just the one

Logged-In Check for current moved from child  Event Display to parent Event Page and passed down via props.

Event Page Header changed to render the correct Logout/Home button depending on if logged-in or not.